### PR TITLE
The default build configuration should specify a src dir

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ let _taskMap = {} as { [key: string]: IExecutable };
 let _uniqueTasks = [];
 
 let _buildConfig: IBuildConfig = {
+  srcFolder: 'src',
   distFolder: 'dist',
   libAMDFolder: null,
   libFolder: 'lib',


### PR DESCRIPTION
Just noticed that this is not set by default. It should probably be src, as this is what we and onedrive are using, and is the most common practice. This change should have low risk of regression since this value has been set to undefined in the meantime, meaning any projects with a special source dir have already overridden this.