### PR TITLE
Set the build config during gulp nuke

### DIFF
--- a/src/GulpTask.ts
+++ b/src/GulpTask.ts
@@ -54,8 +54,7 @@ public log(message: string): void {
     fileError(this.name, filePath, line, column, errorCode, message);
   }
 
-  public getNukeMatch(config: IBuildConfig): string[] {
-    this.buildConfig = config;
+  public getNukeMatch(buildConfig: IBuildConfig, taskConfig: TASK_CONFIG = this.taskConfig): string[] {
     return this.nukeMatch;
   }
 

--- a/src/GulpTask.ts
+++ b/src/GulpTask.ts
@@ -54,7 +54,8 @@ public log(message: string): void {
     fileError(this.name, filePath, line, column, errorCode, message);
   }
 
-  public getNukeMatch(): string[] {
+  public getNukeMatch(config: IBuildConfig): string[] {
+    this.buildConfig = config;
     return this.nukeMatch;
   }
 

--- a/src/IExecutable.ts
+++ b/src/IExecutable.ts
@@ -11,5 +11,5 @@ export interface IExecutable {
   isEnabled?: () => boolean;
 
   /** Optional method to indicate directory matches to clean up when the nuke task is run. */
-  getNukeMatch?: () => string[];
+  getNukeMatch?: (config: IBuildConfig) => string[];
 }

--- a/src/IExecutable.ts
+++ b/src/IExecutable.ts
@@ -11,5 +11,5 @@ export interface IExecutable {
   isEnabled?: () => boolean;
 
   /** Optional method to indicate directory matches to clean up when the nuke task is run. */
-  getNukeMatch?: (config: IBuildConfig) => string[];
+  getNukeMatch?: (config: IBuildConfig, taskConfig?: {}) => string[];
 }

--- a/src/NukeTask.ts
+++ b/src/NukeTask.ts
@@ -29,6 +29,8 @@ export class NukeTask extends GulpTask<INukeConfig> {
     // Give each registered task an opportunity to add their own nuke paths.
     for (let executable of this.buildConfig.uniqueTasks) {
       if (executable.getNukeMatch) {
+        // Set the build config, as tasks need this to build up paths
+        (executable as GulpTask<Object>).buildConfig = this.buildConfig;
         nukePaths = nukePaths.concat(executable.getNukeMatch());
       }
     }

--- a/src/NukeTask.ts
+++ b/src/NukeTask.ts
@@ -27,11 +27,10 @@ export class NukeTask extends GulpTask<INukeConfig> {
     ];
 
     // Give each registered task an opportunity to add their own nuke paths.
-    for (let executable of this.buildConfig.uniqueTasks) {
+    for (const executable of this.buildConfig.uniqueTasks) {
       if (executable.getNukeMatch) {
         // Set the build config, as tasks need this to build up paths
-        (executable as GulpTask<Object>).buildConfig = this.buildConfig;
-        nukePaths = nukePaths.concat(executable.getNukeMatch());
+        nukePaths = nukePaths.concat(executable.getNukeMatch(this.buildConfig));
       }
     }
 


### PR DESCRIPTION
Currently this is not set, so many tasks cannot properly set their nukeMatches

@iclanton @dzearing @pgonzal 